### PR TITLE
Installing missing librsvg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN apk -U upgrade \
         openldap \
         libgomp \
         imagemagick \
+        librsvg \
         zlib \
  && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
  && docker-php-ext-configure ldap \


### PR DESCRIPTION
Since using alpine 3.19 Nextcloud is reporting:

'The PHP module "imagick" in this instance has no SVG support.'